### PR TITLE
Add Support for Google Cloud A4 and A4X Machine Types

### DIFF
--- a/instances/README.md
+++ b/instances/README.md
@@ -11,7 +11,9 @@ The SQL files are read during the [build](../build/) process.
 
 * [Series](./series/)
 	* [A2](./series/a2.sql)
-	* [A3](./series/a2.sql)
+	* [A3](./series/a3.sql)
+	* [A4](./series/a4.sql)
+	* [A4X](./series/a4x.sql)
 	* [C2](./series/c2.sql)
 	* [C2D](./series/c2d.sql)
 	* [C3](./series/c3.sql)
@@ -50,7 +52,10 @@ The cost per machine type in region and licenses are added with the [gcosts](htt
 		<a href="https://cloud.google.com/compute/docs/machine-types#machine_type_comparison" rel="nofollow">Machine series comparison</a>
 		<ul>
 			<li>
-				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#a2_vms" rel="nofollow">A2</a> and
+				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#a2_vms" rel="nofollow">A2</a>,
+				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#a3-vms" rel="nofollow">A3</a>,
+				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4-vms" rel="nofollow">A4</a>,
+				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4x-vms" rel="nofollow">A4X</a> and
 				<a href="https://cloud.google.com/compute/docs/accelerator-optimized-machines#g2-vms" rel="nofollow">G2</a> accelerator optimized machines
 			</li>
 			<li>
@@ -85,4 +90,3 @@ The cost per machine type in region and licenses are added with the [gcosts](htt
 	<li><a href="https://cloud.google.com/solutions/sap/docs/certifications-sap-apps#sap-certified-vms" rel="nofollow">Certified SAP applications on Google Cloud</a></li>
 	<li><a href="https://cloud.google.com/solutions/sap/docs/certifications-sap-hana#hana-cert-table-vms" rel="nofollow">Certified machine types for SAP HANA</a></li>
 </ul>
-

--- a/instances/series/a4.sql
+++ b/instances/series/a4.sql
@@ -1,0 +1,11 @@
+/* A4 Accelerator-optimized machine family */
+/* https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4-vms */
+/* https://cloud.google.com/compute/docs/gpus#a4 */
+UPDATE instances SET
+series      = 'a4',
+family      = 'Accelerator-optimized',
+cpuPlatform = 'Sapphire Rapids',
+localSsd    = '12000',
+bandwidth   = '3600',
+spot        = '1'
+WHERE name LIKE 'a4-%';

--- a/instances/series/a4x.sql
+++ b/instances/series/a4x.sql
@@ -1,0 +1,12 @@
+/* A4X Accelerator-optimized machine family */
+/* https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4x-vms */
+/* https://cloud.google.com/compute/docs/gpus#gb200-gpus */
+UPDATE instances SET
+series      = 'a4x',
+family      = 'Accelerator-optimized',
+cpuPlatform = 'ARM Neoverse V2',
+localSsd    = '12000',
+bandwidth   = '2000',
+arm         = '1',
+spot        = '1'
+WHERE name LIKE 'a4x-%';

--- a/instances/series/gpu/gpu_names.sql
+++ b/instances/series/gpu/gpu_names.sql
@@ -20,7 +20,12 @@ UPDATE instances SET acceleratorType = "NVIDIA V100"       WHERE acceleratorType
 UPDATE instances SET acceleratorType = "NVIDIA P100 vWS"   WHERE acceleratorType LIKE "nvidia-tesla-p100-vws";
 UPDATE instances SET acceleratorType = "NVIDIA P100"       WHERE acceleratorType LIKE "nvidia-tesla-p100";
 
+UPDATE instances SET acceleratorType = "NVIDIA H200 141GB"     WHERE acceleratorType LIKE "nvidia-h200-141gb";
+
 UPDATE instances SET acceleratorType = "NVIDIA H100 80GB"      WHERE acceleratorType LIKE "nvidia-h100-80gb";
 UPDATE instances SET acceleratorType = "NVIDIA H100 80GB Mega" WHERE acceleratorType LIKE "nvidia-h100-mega-80gb";
+
+UPDATE instances SET acceleratorType = "NVIDIA B200"           WHERE acceleratorType LIKE "nvidia-b200";
+UPDATE instances SET acceleratorType = "NVIDIA GB200"          WHERE acceleratorType LIKE "nvidia-gb200";
 
 UPDATE instances SET acceleratorType = "NVIDIA K80 (EOL!)" WHERE acceleratorType LIKE "nvidia-tesla-k80";


### PR DESCRIPTION

## Summary

This PR adds support for the newly released Google Cloud Compute Engine machine types **A4** and **A4X**, along with their associated NVIDIA GPU models (B200, GB200, and H200).

## Motivation

Google Cloud has recently announced the A4 and A4X machine series featuring the latest NVIDIA Blackwell GPU architecture. These new accelerator-optimized machine types are designed for foundation model training and serving, representing a significant advancement in AI/ML compute capabilities.

Reference: https://cloud.google.com/compute/docs/gpus/

## Changes Made

### New Machine Type Configurations

#### 1. A4 Machine Series (`instances/series/a4.sql`)
- **Family**: Accelerator-optimized
- **GPU**: NVIDIA B200 Blackwell GPUs
- **CPU Platform**: Sapphire Rapids
- **Local SSD**: 12,000 GiB
- **Network Bandwidth**: 3,600 Gbps
- **Spot VM Support**: Enabled
- **Machine Type**: `a4-highgpu-8g`
  - 224 vCPUs
  - 3,968 GB memory
  - 8x NVIDIA B200 GPUs (1,440 GB total GPU memory)

#### 2. A4X Machine Series (`instances/series/a4x.sql`)
- **Family**: Accelerator-optimized
- **GPU**: NVIDIA GB200 Grace Blackwell Superchips
- **CPU Platform**: ARM Neoverse V2
- **Local SSD**: 12,000 GiB
- **Network Bandwidth**: 2,000 Gbps
- **ARM Architecture**: Supported
- **Spot VM Support**: Enabled
- **Machine Type**: `a4x-highgpu-4g`
  - 140 vCPUs
  - 884 GB memory
  - 4x NVIDIA GB200 GPUs (720 GB total GPU memory)

### GPU Model Support

Added support for the following NVIDIA GPU models in `instances/series/gpu/gpu_names.sql`:
- **NVIDIA H200 141GB** (`nvidia-h200-141gb`) - Used in A3 Ultra
- **NVIDIA B200** (`nvidia-b200`) - Used in A4
- **NVIDIA GB200** (`nvidia-gb200`) - Used in A4X

### Documentation Updates

Updated `instances/README.md` to:
- Add A4 and A4X to the machine types list
- Fix A3 link (was incorrectly pointing to `a2.sql`)
- Update resources section to reference A3, A4, and A4X accelerator-optimized machines

## Testing

All SQL files follow the existing project patterns and schema:
- Consistent formatting with existing machine type configurations
- Proper series and family classification
- Accurate specifications from official Google Cloud documentation

## References

- [Google Cloud GPU Machine Types](https://cloud.google.com/compute/docs/gpus)
- [A4 Machine Series](https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4-vms)
- [A4X Machine Series](https://cloud.google.com/compute/docs/accelerator-optimized-machines#a4x-vms)
- [NVIDIA B200 GPUs](https://www.nvidia.com/en-us/data-center/b200/)
- [NVIDIA GB200 NVL72](https://www.nvidia.com/en-us/data-center/gb200-nvl72/)

## Checklist

- [x] Created new SQL configuration files for A4 and A4X machine types
- [x] Updated GPU names mapping for new NVIDIA models
- [x] Updated documentation to reflect new machine types
- [x] Followed existing code style and patterns
- [x] All changes are based on official Google Cloud documentation
- [x] Clear and descriptive commit messages

## Additional Notes

These machine types represent Google Cloud's latest offerings for AI/ML workloads:
- **A4** is optimized for foundation model training and serving with NVIDIA B200 GPUs
- **A4X** features GB200 Grace Blackwell Superchips combining ARM CPUs with B200 GPUs for exascale AI computing

Both machine types require capacity reservation or specific provisioning methods as outlined in the Google Cloud documentation.
