### PR TITLE
Add G4 accelerator-optimized machine series

### DIFF
--- a/instances/README.md
+++ b/instances/README.md
@@ -21,6 +21,7 @@ The SQL files are read during the [build](../build/) process.
 	* [C4D](./series/c4d.sql)
 	* [E2](./series/e2.sql)
 	* [G2](./series/g2.sql)
+	* [G4](./series/g4.sql)
 	* [M1](./series/m1.sql)
 	* [M2](./series/m2.sql)
 	* [M3](./series/m3.sql)

--- a/instances/series/g4.sql
+++ b/instances/series/g4.sql
@@ -1,0 +1,17 @@
+/* G4 Accelerator-optimized machines */
+/* https://cloud.google.com/compute/docs/machine-types#machine_type_comparison */
+/* https://cloud.google.com/compute/docs/accelerator-optimized-machines#g4-vms */
+UPDATE instances SET
+series      = 'g4',
+family      = 'Accelerator-optimized',
+cpuPlatform = 'Genoa',
+localSsd    = '1',
+spot        = '1'
+WHERE name LIKE 'g4-%';
+UPDATE instances SET bandwidth = '20'  WHERE name LIKE 'g4-standard-6';
+UPDATE instances SET bandwidth = '20'  WHERE name LIKE 'g4-standard-12';
+UPDATE instances SET bandwidth = '20'  WHERE name LIKE 'g4-standard-24';
+UPDATE instances SET bandwidth = '50'  WHERE name LIKE 'g4-standard-48';
+UPDATE instances SET bandwidth = '100' WHERE name LIKE 'g4-standard-96';
+UPDATE instances SET bandwidth = '200' WHERE name LIKE 'g4-standard-192';
+UPDATE instances SET bandwidth = '400' WHERE name LIKE 'g4-standard-384';

--- a/instances/series/g4.sql
+++ b/instances/series/g4.sql
@@ -4,7 +4,7 @@
 UPDATE instances SET
 series      = 'g4',
 family      = 'Accelerator-optimized',
-cpuPlatform = 'Genoa',
+cpuPlatform = 'Turin',
 localSsd    = '1',
 spot        = '1'
 WHERE name LIKE 'g4-%';

--- a/instances/series/gpu/gpu_names.sql
+++ b/instances/series/gpu/gpu_names.sql
@@ -3,6 +3,8 @@
  * https://cloud.google.com/compute/docs/gpus#gpus-list
  */
 
+UPDATE instances SET acceleratorType = 'NVIDIA RTX PRO 6000' WHERE acceleratorType LIKE 'nvidia-rtx-pro-6000';
+
 UPDATE instances SET acceleratorType = 'NVIDIA L4 vWS'     WHERE acceleratorType LIKE 'nvidia-l4-vws';
 UPDATE instances SET acceleratorType = 'NVIDIA L4'         WHERE acceleratorType LIKE 'nvidia-l4';
 


### PR DESCRIPTION
## Please Complete the Following

- [x] I read `CONTRIBUTING.md`
- [x] I used tabs to indent
- [x] I have tested my change

## Notes

Adds support for the G4 accelerator-optimized machine series (NVIDIA RTX PRO 6000, AMD EPYC Genoa).

Changes:
- `instances/series/g4.sql` — new series metadata: `Accelerator-optimized` family, `Genoa` CPU platform, local SSD enabled, Spot enabled, per-size network bandwidth (20–400 Gbps)
- `instances/series/gpu/gpu_names.sql` — adds `nvidia-rtx-pro-6000` → `NVIDIA RTX PRO 6000` display name mapping
- `instances/README.md` — registers G4 in the series list

Bandwidth values sourced from https://cloud.google.com/compute/docs/gpus#gpus-list.

Closes #46